### PR TITLE
Add a new route in order to retrieve the salt id

### DIFF
--- a/packages/origin-device-nvenergy-api/src/energy/energy.controller.ts
+++ b/packages/origin-device-nvenergy-api/src/energy/energy.controller.ts
@@ -1,5 +1,5 @@
 import { ReadsService, FilterDTO } from "@energyweb/energy-api";
-import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+import { Body, Controller, Get, Param, Post, Query, HttpException, HttpStatus } from "@nestjs/common";
 import {
   ApiUnauthorizedResponse,
   ApiUnprocessableEntityResponse,
@@ -33,6 +33,15 @@ export class EnergyController {
   @Get("/salt")
   public generateSalt(): SaltDTO {
     return this.energyService.generateSalt();
+  }
+
+  @Get("/salt/:salt")
+  public getSalt(
+    @Param("salt") salt: string
+    ): SaltDTO {
+    const res = this.energyService.getSalt(salt)
+    if (!res) throw new HttpException('Not Found', HttpStatus.NOT_FOUND)
+    return res
   }
 
   @Get("/:meter")

--- a/packages/origin-device-nvenergy-api/src/energy/energy.service.ts
+++ b/packages/origin-device-nvenergy-api/src/energy/energy.service.ts
@@ -48,6 +48,11 @@ export class EnergyService {
     });
   }
 
+  public getSalt(salt: string) {
+    const id = this.salt.indexOf(salt)
+    return id !== -1 ? { id, salt } : undefined
+  }
+
   public generateSalt() {
     const bytes = ethers.utils.randomBytes(16);
     const hex = ethers.utils.hexlify(bytes);


### PR DESCRIPTION
Hello sir, from what i have understood, we would be knowing the salt itself from the meter payload. In order to correlate it later, i added a way to get one of `SaltDTO` by salt in order to later correlate with the stored `SmartMeterReadDTO`.